### PR TITLE
cuckoo.py is running properly after updating config files

### DIFF
--- a/analyzer/android/lib/api/adb.py
+++ b/analyzer/android/lib/api/adb.py
@@ -108,9 +108,8 @@ def execute_sample(package,activity):
     """Execute the sample on the emulator via adb"""
     log.info("executing sample on emulator:adb shell am start -n " +package+"/"+activity)
     str=""
-    proc = subprocess.Popen("/system/bin/am start -n" + package+"/"+activity, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, executable='/system/bin/sh')#adb shell am start -n $pkg/$act
-    #str = os.popen("/system/bin/am start -n "+package+"/"+activity).read()
-    #this os.open() is no more supported(depricated) on python latest version. Instaed use subprocess.Popen() function.
+    #proc = subprocess.Popen("/system/bin/am start -n" + package+"/"+activity, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, executable='/system/bin/sh')#adb shell am start -n $pkg/$act
+    str = os.popen("/system/bin/am start -n "+package+"/"+activity).read()
     lines = str.split("\n")
     for line in lines:
         if("Error" in line):

--- a/analyzer/android/lib/api/adb.py
+++ b/analyzer/android/lib/api/adb.py
@@ -108,8 +108,9 @@ def execute_sample(package,activity):
     """Execute the sample on the emulator via adb"""
     log.info("executing sample on emulator:adb shell am start -n " +package+"/"+activity)
     str=""
-    #proc = subprocess.Popen(["/system/bin/am","start","-n", package+"/"+activity], stdout=subprocess.PIPE, stderr=subprocess.PIPE)#adb shell am start -n $pkg/$act
-    str = os.popen("/system/bin/am start -n "+package+"/"+activity).read()
+    proc = subprocess.Popen("/system/bin/am start -n" + package+"/"+activity, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, executable='/system/bin/sh')#adb shell am start -n $pkg/$act
+    #str = os.popen("/system/bin/am start -n "+package+"/"+activity).read()
+    #this os.open() is no more supported(depricated) on python latest version. Instaed use subprocess.Popen() function.
     lines = str.split("\n")
     for line in lines:
         if("Error" in line):

--- a/analyzer/android/lib/api/adb.py
+++ b/analyzer/android/lib/api/adb.py
@@ -108,7 +108,7 @@ def execute_sample(package,activity):
     """Execute the sample on the emulator via adb"""
     log.info("executing sample on emulator:adb shell am start -n " +package+"/"+activity)
     str=""
-    #proc = subprocess.Popen("/system/bin/am start -n" + package+"/"+activity, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, executable='/system/bin/sh')#adb shell am start -n $pkg/$act
+    #proc = subprocess.Popen(["/system/bin/am","start","-n", package+"/"+activity], stdout=subprocess.PIPE, stderr=subprocess.PIPE)#adb shell am start -n $pkg/$act
     str = os.popen("/system/bin/am start -n "+package+"/"+activity).read()
     lines = str.split("\n")
     for line in lines:

--- a/conf/avd.conf
+++ b/conf/avd.conf
@@ -1,12 +1,12 @@
 [avd]
 #Path to the local installation of the android emulator
-emulator_path = /Applications/adt-bundle/sdk/tools/emulator
+emulator_path = /home/test/Android/Sdk/emulator/emulator
 
 #Path to the local installation of the adb - android debug bridge utility.
-adb_path = /Applications/adt-bundle/sdk/platform-tools/adb
+adb_path = /home/test/Android/Sdk/platform-tools/adb
 
 #Path to the emulator machine files is located
-avd_path = /Users/guardianangel/.android/avd
+avd_path = /home/test/.android/avd
 
 #name of the reference machine that is used to duplicate
 reference_machine = aosx

--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -1,0 +1,121 @@
+[cuckoo]
+# Enable or disable startup version check. When enabled, Cuckoo will connect
+# to a remote location to verify whether the running version is the latest
+# one available.
+version_check = on
+
+# If turned on, Cuckoo will delete the original file after its analysis
+# has been completed.
+delete_original = off
+
+# If turned on, Cuckoo will delete the copy of the original file in the
+# local binaries repository after the analysis has finished. (On *nix this
+# will also invalidate the file called "binary" in each analysis directory,
+# as this is a symlink.)
+delete_bin_copy = off
+
+# Specify the name of the machinery module to use, this module will
+# define the interaction between Cuckoo and your virtualization software
+# of choice.
+machinery = avd
+
+# Enable creation of memory dump of the analysis machine before shutting
+# down. Even if turned off, this functionality can also be enabled at
+# submission. Currently available for: VirtualBox and libvirt modules (KVM).
+memory_dump = off
+
+# When the timeout of an analysis is hit, the VM is just killed by default.
+# For some long-running setups it might be interesting to terminate the
+# moinitored processes before killing the VM so that connections are closed.
+terminate_processes = off
+
+# Enable automatically re-schedule of "broken" tasks each startup.
+# Each task found in status "processing" is re-queued for analysis.
+reschedule = off
+
+# Enable processing of results within the main cuckoo process.
+# This is the default behavior but can be switched off for setups that
+#  require high stability and process the results in a separate task.
+process_results = on
+
+# Limit the amount of analysis jobs a Cuckoo process goes through.
+# This can be used together with a watchdog to mitigate risk of memory leaks.
+max_analysis_count = 0
+
+# Limit the number of concurrently executing analysis machines.
+# This may be useful on systems with limited resources.
+# Set to 0 to disable any limits.
+max_machines_count = 0
+
+# Minimum amount of free space (in MB) available before starting a new task. 
+# This tries to avoid failing an analysis because the reports can't be written 
+# due out-of-diskspace errors. Setting this value to 0 disables the check.
+# (Note: this feature is currently not supported under Windows.)
+freespace = 64
+
+# Temporary directory containing the files uploaded through Cuckoo interfaces
+# (web.py, api.py, Django web interface).
+tmppath = /tmp
+
+[resultserver]
+# The Result Server is used to receive in real time the behavioral logs
+# produced by the analyzer.
+# Specify the IP address of the host. The analysis machines should be able
+# to contact the host through such address, so make sure it's valid.
+# NOTE: if you set resultserver IP to 0.0.0.0 you have to set the option
+# `resultserver_ip` for all your virtual machines in machinery configuration.
+#ip = 192.168.56.1
+ip = 0.0.0.0
+
+# Specify a port number to bind the result server on.
+port = 2042
+
+# Should the server write the legacy CSV format?
+# (if you have any custom processing on those, switch this on)
+store_csvs = off
+
+# Maximum size of uploaded files from VM (screenshots, dropped files, log)
+# The value is expressed in bytes, by default 10Mb.
+upload_max_size = 10485760
+
+[processing]
+# Set the maximum size of analyses generated files to process. This is used
+# to avoid the processing of big files which may take a lot of processing
+# time. The value is expressed in bytes, by default 100Mb.
+analysis_size_limit = 104857600
+
+# Enable or disable DNS lookups.
+resolve_dns = on
+
+# Enable PCAP sorting, needed for the connection content view in the web interface.
+sort_pcap = on
+
+[database]
+# Specify the database connection string.
+# Examples, see documentation for more:
+# sqlite:///foo.db
+# postgresql://foo:bar@localhost:5432/mydatabase
+# mysql://foo:bar@localhost/mydatabase
+# If empty, default is a SQLite in db/cuckoo.db.
+connection = sqlite:///foo.db
+
+# Database connection timeout in seconds.
+# If empty, default is set to 60 seconds.
+timeout =
+
+[timeouts]
+# Set the default analysis timeout expressed in seconds. This value will be
+# used to define after how many seconds the analysis will terminate unless
+# otherwise specified at submission.
+default = 240
+
+# Set the critical timeout expressed in seconds. After this timeout is hit
+# Cuckoo will consider the analysis failed and it will shutdown the machine
+# no matter what. When this happens the analysis results will most likely
+# be lost. Make sure to have a critical timeout greater than the
+# default timeout.
+critical = 250
+
+# Maximum time to wait for virtual machine status change. For example when
+# shutting down a vm. Default is 300 seconds.
+vm_state = 300

--- a/conf/processing.conf
+++ b/conf/processing.conf
@@ -1,0 +1,58 @@
+# Enable or disable the available processing modules [on/off].
+# If you add a custom processing module to your Cuckoo setup, you have to add
+# a dedicated entry in this file, or it won't be executed.
+# You can also add additional options under the section of your module and
+# they will be available in your Python class.
+
+[analysisinfo]
+enabled = yes
+
+[behavior]
+enabled = yes
+
+[debug]
+enabled = yes
+
+[dropped]
+enabled = yes
+
+[memory]
+enabled = no
+
+[network]
+enabled = yes
+
+[procmemory]
+enabled = yes
+
+[static]
+enabled = yes
+
+[strings]
+enabled = yes
+
+[targetinfo]
+enabled = yes
+
+[virustotal]
+enabled = yes
+timeout = 60
+# Add your VirusTotal API key here. The default API key, kindly provided
+# by the VirusTotal team, should enable you with a sufficient throughput
+# and while being shared with all our users, it shouldn't affect your use.
+key = a0283a2c3d55728300d064874239b5346fb991317e8449fe43c902879d758088
+
+[apkinfo]
+enabled = yes
+#Decompiling dex with androguard in a heavy operation and for a big dex's
+#he can really consume performance from the cuckoo host ,so it's recommended to limit the size of dex that you will decompile
+#decompilation_threshold=2000000
+
+[droidmon]
+enabled = yes
+
+[googleplay]
+enabled = no
+android_id = 
+google_login = 
+google_password = 


### PR DESCRIPTION
I have debugged the issue #70 and found the root cause 


Root cause:-
(1) Resolve all dependency
(2) we need to configure file properly at location:-
/conf/avd.conf
/conf/cuckoo.conf
/conf/processing.conf


We need to make below chages to cuckoodroid/config/*.conf file :- 
 
[googleplay]
enabled=No

#path to emulator machine
avd_path = /~/.android/avd

Repro setup on my local system.

Setup: -
Ubuntu 18.04
Python 3.8
Android API 18
Android Linux kernel version 4.4

I have throughly tested the issue after making the above changes. 
No repro after resolving after two issues.

This bug is fixed, I have raised the pull request to merge 